### PR TITLE
Fixed bug (tests WIP) - return function from selector

### DIFF
--- a/__tests__/reusable.test.js
+++ b/__tests__/reusable.test.js
@@ -164,4 +164,40 @@ describe('reusable', () => {
 
     expect(result.error.toString()).toMatchSnapshot();
   });
+  it('should allow to return a function value', () => {
+    const callback = jest.fn();
+    const useSomething = reusable(() => callback);
+    const {result} = renderHook(useSomething, {
+      wrapper: ReusableProvider
+    });
+    
+    expect(result.current).toBe(callback);
+    expect(callback.mock.calls.length).toBe(0);
+  });
+});
+describe('selectors', () => {
+
+  it('should allow to use a selector', () => {
+    const useSomething = reusable(() => useState(1));
+    const useSelector = () => useSomething(state => state[0]);
+    const { result } = renderHook(useSelector, {
+      wrapper: ReusableProvider
+    });
+    const state = result.current;
+      
+    expect(state).toBe(1);
+  });
+  
+  it('should allow to use a selector that returns a function', () => {
+    const callback = jest.fn();
+    const useSomething = reusable(() => ({ callback }));
+    const useSelector = () => useSomething(state => state.callback);
+    const {result} = renderHook(useSelector, {
+      wrapper: ReusableProvider
+    });
+    
+    expect(result.current).toBe(callback);
+    expect(callback.mock.calls.length).toBe(0);
+  });
+
 });

--- a/sandbox/src/index.js
+++ b/sandbox/src/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useCallback } from "react";
 import ReactDOM from "react-dom";
 import { ReusableProvider, reusable } from "../../dist/reusable";
 
@@ -8,6 +8,14 @@ const useCounter = reusable(() => {
 
 const useStep = reusable(() => {
   return useState(0);
+});
+
+const useFnObject = reusable(() => {
+  const [state, setState] = useState(0);
+  const callback = () => console.log('callback') || setState(10);
+  return {
+    callback
+  };
 });
 
 const useMultiply = reusable(() => {
@@ -55,6 +63,8 @@ const Multiply = () => {
 
 const App = () => {
   const [showMultiply, setShowMultiply] = useState(true);
+  const callback = useFnObject(state => state.callback);
+  setTimeout(() => callback(), 1000);
 
   return (
     <div>

--- a/src/react-reusable.js
+++ b/src/react-reusable.js
@@ -55,7 +55,7 @@ const useReuse = (fn, selector = identity, areEqual = shallowEqual) => {
     return unit.subscribe((newValue) => {
       const selectedNewValue = selector(newValue);
       if (!areEqual(selectedNewValue, localCopy)) {
-        setLocalCopy(selectedNewValue);
+        setLocalCopy(() => selectedNewValue);
       }
     });
   }, [unit, localCopy, selector, areEqual]);


### PR DESCRIPTION
When selector (or entire store) returns a function, we use it in `setLocalCopy`, and react treats it as a setter function instead of the actual value.